### PR TITLE
chore: upgrade zod to v4

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,20 +10,21 @@
 			"license": "MIT",
 			"dependencies": {
 				"emittery": "^1.2.0",
-				"jsonrepair": "^3.13.0",
-				"zod": "^3.24.1",
-				"zod-to-json-schema": "^3.24.6"
+				"jsonrepair": "^3.13.1",
+				"zod": "^4.1.11"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.1.4",
-				"@types/node": "^24.2.1",
-				"dotenv": "^17.2.1",
-				"tsx": "4.20.4",
-				"typescript": "^5.9.2"
+				"@biomejs/biome": "2.2.5",
+				"@types/node": "^24.6.2",
+				"dotenv": "^17.2.3",
+				"tsx": "4.20.6",
+				"typescript": "^5.9.3"
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.1.4",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.2.5.tgz",
+			"integrity": "sha512-zcIi+163Rc3HtyHbEO7CjeHq8DjQRs40HsGbW6vx2WI0tg8mYQOPouhvHSyEnCBAorfYNnKdR64/IxO7xQ5faw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -37,18 +38,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.1.4",
-				"@biomejs/cli-darwin-x64": "2.1.4",
-				"@biomejs/cli-linux-arm64": "2.1.4",
-				"@biomejs/cli-linux-arm64-musl": "2.1.4",
-				"@biomejs/cli-linux-x64": "2.1.4",
-				"@biomejs/cli-linux-x64-musl": "2.1.4",
-				"@biomejs/cli-win32-arm64": "2.1.4",
-				"@biomejs/cli-win32-x64": "2.1.4"
+				"@biomejs/cli-darwin-arm64": "2.2.5",
+				"@biomejs/cli-darwin-x64": "2.2.5",
+				"@biomejs/cli-linux-arm64": "2.2.5",
+				"@biomejs/cli-linux-arm64-musl": "2.2.5",
+				"@biomejs/cli-linux-x64": "2.2.5",
+				"@biomejs/cli-linux-x64-musl": "2.2.5",
+				"@biomejs/cli-win32-arm64": "2.2.5",
+				"@biomejs/cli-win32-x64": "2.2.5"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.1.4",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.5.tgz",
+			"integrity": "sha512-MYT+nZ38wEIWVcL5xLyOhYQQ7nlWD0b/4mgATW2c8dvq7R4OQjt/XGXFkXrmtWmQofaIM14L7V8qIz/M+bx5QQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -62,10 +65,129 @@
 				"node": ">=14.21.3"
 			}
 		},
+		"node_modules/@biomejs/cli-darwin-x64": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.5.tgz",
+			"integrity": "sha512-FLIEl73fv0R7dI10EnEiZLw+IMz3mWLnF95ASDI0kbx6DDLJjWxE5JxxBfmG+udz1hIDd3fr5wsuP7nwuTRdAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.5.tgz",
+			"integrity": "sha512-5DjiiDfHqGgR2MS9D+AZ8kOfrzTGqLKywn8hoXpXXlJXIECGQ32t+gt/uiS2XyGBM2XQhR6ztUvbjZWeccFMoQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.5.tgz",
+			"integrity": "sha512-5Ov2wgAFwqDvQiESnu7b9ufD1faRa+40uwrohgBopeY84El2TnBDoMNXx6iuQdreoFGjwW8vH6k68G21EpNERw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.5.tgz",
+			"integrity": "sha512-fq9meKm1AEXeAWan3uCg6XSP5ObA6F/Ovm89TwaMiy1DNIwdgxPkNwxlXJX8iM6oRbFysYeGnT0OG8diCWb9ew==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.5.tgz",
+			"integrity": "sha512-AVqLCDb/6K7aPNIcxHaTQj01sl1m989CJIQFQEaiQkGr2EQwyOpaATJ473h+nXDUuAcREhccfRpe/tu+0wu0eQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-arm64": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.5.tgz",
+			"integrity": "sha512-xaOIad4wBambwJa6mdp1FigYSIF9i7PCqRbvBqtIi9y29QtPVQ13sDGtUnsRoe6SjL10auMzQ6YAe+B3RpZXVg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-x64": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.5.tgz",
+			"integrity": "sha512-F/jhuXCssPFAuciMhHKk00xnCAxJRS/pUzVfXYmOMUp//XW7mO6QeCjsjvnm8L4AO/dG2VOB0O+fJPiJ2uXtIw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
-			"integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+			"integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -80,9 +202,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
-			"integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+			"integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
 			"cpu": [
 				"arm"
 			],
@@ -97,9 +219,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
-			"integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+			"integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
 			"cpu": [
 				"arm64"
 			],
@@ -114,9 +236,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
-			"integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+			"integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
 			"cpu": [
 				"x64"
 			],
@@ -131,9 +253,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
-			"integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+			"integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
 			"cpu": [
 				"arm64"
 			],
@@ -148,9 +270,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
-			"integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+			"integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
 			"cpu": [
 				"x64"
 			],
@@ -165,9 +287,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
-			"integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+			"integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
 			"cpu": [
 				"arm64"
 			],
@@ -182,9 +304,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
-			"integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+			"integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
 			"cpu": [
 				"x64"
 			],
@@ -199,9 +321,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
-			"integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+			"integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
 			"cpu": [
 				"arm"
 			],
@@ -216,9 +338,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
-			"integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+			"integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -233,9 +355,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
-			"integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+			"integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -250,9 +372,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
-			"integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+			"integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
 			"cpu": [
 				"loong64"
 			],
@@ -267,9 +389,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
-			"integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+			"integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -284,9 +406,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
-			"integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+			"integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -301,9 +423,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
-			"integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+			"integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -318,9 +440,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
-			"integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+			"integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
 			"cpu": [
 				"s390x"
 			],
@@ -335,9 +457,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
-			"integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+			"integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
 			"cpu": [
 				"x64"
 			],
@@ -352,9 +474,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
-			"integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+			"integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
 			"cpu": [
 				"arm64"
 			],
@@ -369,9 +491,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
-			"integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+			"integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
 			"cpu": [
 				"x64"
 			],
@@ -386,9 +508,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
-			"integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+			"integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
 			"cpu": [
 				"arm64"
 			],
@@ -403,9 +525,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
-			"integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+			"integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
 			"cpu": [
 				"x64"
 			],
@@ -420,9 +542,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
-			"integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+			"integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
 			"cpu": [
 				"arm64"
 			],
@@ -437,9 +559,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
-			"integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+			"integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
 			"cpu": [
 				"x64"
 			],
@@ -454,9 +576,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
-			"integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+			"integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
 			"cpu": [
 				"arm64"
 			],
@@ -471,9 +593,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
-			"integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+			"integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
 			"cpu": [
 				"ia32"
 			],
@@ -488,9 +610,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
-			"integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+			"integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
 			"cpu": [
 				"x64"
 			],
@@ -505,17 +627,19 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "24.2.1",
+			"version": "24.6.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+			"integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.10.0"
+				"undici-types": "~7.13.0"
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.2.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-			"integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+			"version": "17.2.3",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -538,9 +662,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.8",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
-			"integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
+			"version": "0.25.10",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+			"integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -551,32 +675,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.8",
-				"@esbuild/android-arm": "0.25.8",
-				"@esbuild/android-arm64": "0.25.8",
-				"@esbuild/android-x64": "0.25.8",
-				"@esbuild/darwin-arm64": "0.25.8",
-				"@esbuild/darwin-x64": "0.25.8",
-				"@esbuild/freebsd-arm64": "0.25.8",
-				"@esbuild/freebsd-x64": "0.25.8",
-				"@esbuild/linux-arm": "0.25.8",
-				"@esbuild/linux-arm64": "0.25.8",
-				"@esbuild/linux-ia32": "0.25.8",
-				"@esbuild/linux-loong64": "0.25.8",
-				"@esbuild/linux-mips64el": "0.25.8",
-				"@esbuild/linux-ppc64": "0.25.8",
-				"@esbuild/linux-riscv64": "0.25.8",
-				"@esbuild/linux-s390x": "0.25.8",
-				"@esbuild/linux-x64": "0.25.8",
-				"@esbuild/netbsd-arm64": "0.25.8",
-				"@esbuild/netbsd-x64": "0.25.8",
-				"@esbuild/openbsd-arm64": "0.25.8",
-				"@esbuild/openbsd-x64": "0.25.8",
-				"@esbuild/openharmony-arm64": "0.25.8",
-				"@esbuild/sunos-x64": "0.25.8",
-				"@esbuild/win32-arm64": "0.25.8",
-				"@esbuild/win32-ia32": "0.25.8",
-				"@esbuild/win32-x64": "0.25.8"
+				"@esbuild/aix-ppc64": "0.25.10",
+				"@esbuild/android-arm": "0.25.10",
+				"@esbuild/android-arm64": "0.25.10",
+				"@esbuild/android-x64": "0.25.10",
+				"@esbuild/darwin-arm64": "0.25.10",
+				"@esbuild/darwin-x64": "0.25.10",
+				"@esbuild/freebsd-arm64": "0.25.10",
+				"@esbuild/freebsd-x64": "0.25.10",
+				"@esbuild/linux-arm": "0.25.10",
+				"@esbuild/linux-arm64": "0.25.10",
+				"@esbuild/linux-ia32": "0.25.10",
+				"@esbuild/linux-loong64": "0.25.10",
+				"@esbuild/linux-mips64el": "0.25.10",
+				"@esbuild/linux-ppc64": "0.25.10",
+				"@esbuild/linux-riscv64": "0.25.10",
+				"@esbuild/linux-s390x": "0.25.10",
+				"@esbuild/linux-x64": "0.25.10",
+				"@esbuild/netbsd-arm64": "0.25.10",
+				"@esbuild/netbsd-x64": "0.25.10",
+				"@esbuild/openbsd-arm64": "0.25.10",
+				"@esbuild/openbsd-x64": "0.25.10",
+				"@esbuild/openharmony-arm64": "0.25.10",
+				"@esbuild/sunos-x64": "0.25.10",
+				"@esbuild/win32-arm64": "0.25.10",
+				"@esbuild/win32-ia32": "0.25.10",
+				"@esbuild/win32-x64": "0.25.10"
 			}
 		},
 		"node_modules/fsevents": {
@@ -608,9 +732,9 @@
 			}
 		},
 		"node_modules/jsonrepair": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.0.tgz",
-			"integrity": "sha512-5YRzlAQ7tuzV1nAJu3LvDlrKtBFIALHN2+a+I1MGJCt3ldRDBF/bZuvIPzae8Epot6KBXd0awRZZcuoeAsZ/mw==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.1.tgz",
+			"integrity": "sha512-WJeiE0jGfxYmtLwBTEk8+y/mYcaleyLXWaqp5bJu0/ZTSeG0KQq/wWQ8pmnkKenEdN6pdnn6QtcoSUkbqDHWNw==",
 			"license": "ISC",
 			"bin": {
 				"jsonrepair": "bin/cli.js"
@@ -627,9 +751,9 @@
 			}
 		},
 		"node_modules/tsx": {
-			"version": "4.20.4",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
-			"integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+			"version": "4.20.6",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+			"integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -647,9 +771,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -661,26 +785,19 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.10.0",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+			"integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+			"integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.24.6",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-			"integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.24.1"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -33,16 +33,15 @@
 	"type": "module",
 	"dependencies": {
 		"emittery": "^1.2.0",
-		"jsonrepair": "^3.13.0",
-		"zod": "^3.24.1",
-		"zod-to-json-schema": "^3.24.6"
+		"jsonrepair": "^3.13.1",
+		"zod": "^4.1.11"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.1.4",
-		"@types/node": "^24.2.1",
-		"dotenv": "^17.2.1",
-		"tsx": "4.20.4",
-		"typescript": "^5.9.2"
+		"@biomejs/biome": "2.2.5",
+		"@types/node": "^24.6.2",
+		"dotenv": "^17.2.3",
+		"tsx": "4.20.6",
+		"typescript": "^5.9.3"
 	},
 	"files": [
 		"dist"

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,4 +1,4 @@
-import { zodToJsonSchema } from "zod-to-json-schema";
+import * as z from "zod";
 import type { Message, Provider, Tool } from "../types.js";
 
 type JsonSchemaLike = {
@@ -64,7 +64,7 @@ export const Ollama: Provider = {
 		);
 
 		const toolsFormatted = tools?.map((tool: Tool) => {
-			const jsonSchema = zodToJsonSchema(tool.parameters) as JsonSchemaLike;
+			const jsonSchema = z.toJSONSchema(tool.parameters) as JsonSchemaLike;
 			return {
 				type: "function",
 				function: {

--- a/src/providers/openRouter.ts
+++ b/src/providers/openRouter.ts
@@ -1,5 +1,4 @@
-import type { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
+import * as z from "zod";
 import type { Message, Provider, Tool } from "../types.js";
 
 type JsonSchemaLike = {
@@ -113,20 +112,8 @@ export const OpenRouter: Provider = {
 		);
 
 		const toolsFormatted = tools?.map((tool: Tool) => {
-			// For OpenRouter, we need to transform the Zod schema to JSON Schema
-			// This is a simple approach for JSON schema generation
-			// Access the Zod object using type assertion
-			const zodObj = tool.parameters as z.ZodObject<z.ZodRawShape>;
-
-			// Extract shape from the Zod object type
-			const shape = zodObj._def?.shape ? zodObj._def.shape : {};
-
-			// Get field names (currently not used; kept for clarity)
-			const fields = typeof shape === "function" ? shape() : shape;
-			const _fieldNames = Object.keys(fields || {});
-
-			// Convert to JSON schema
-			const jsonSchema = zodToJsonSchema(tool.parameters) as JsonSchemaLike;
+			// Convert to JSON schema using Zod 4's built-in method
+			const jsonSchema = z.toJSONSchema(tool.parameters) as JsonSchemaLike;
 
 			// Check if we're using Cerebras provider with strict mode
 			const providerList = modelOptions?.provider?.only || [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface ToolCall {
 export interface Tool {
 	name: string;
 	description: string;
-	parameters: z.ZodType<unknown, z.ZodTypeDef>;
+	parameters: z.ZodType;
 	handler: (args: Record<string, unknown>) => Promise<string>;
 }
 


### PR DESCRIPTION
## Summary
- upgrade zod to 4.1.11 and drop the zod-to-json-schema dependency
- swap provider tooling over to z.toJSONSchema and align Tool typing with Zod 4
- refresh dev tooling versions and bump the biome schema reference

## Testing
- npm run build
- npm run lint (fails: existing lint warnings in src/providers/ollama.ts and webdemo/src/App.tsx)
